### PR TITLE
Bump defichain dependencies to v0.22.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -526,39 +526,39 @@
       }
     },
     "node_modules/@defichain/jellyfish-address": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-address/-/jellyfish-address-0.18.0.tgz",
-      "integrity": "sha512-xUBHTuBY3Ly8NOWjcjuOMeokIiPC7+6A8fx9xedJKJL5kn+RamPW9pl6HjUhr4RdUFTZ15GhSk0VZ67O3NIM4g==",
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-address/-/jellyfish-address-0.22.0.tgz",
+      "integrity": "sha512-NqlONt0Vkp5nmvg3glxmDWy7boZdyal5/wP55FNJEyDfS4IxpA3sv+GYIDJe2M/u4HFud/lEm6sPnjyT466y4A==",
       "dependencies": {
-        "@defichain/jellyfish-crypto": "^0.18.0",
-        "@defichain/jellyfish-network": "^0.18.0",
-        "@defichain/jellyfish-transaction": "^0.18.0",
+        "@defichain/jellyfish-crypto": "^0.22.0",
+        "@defichain/jellyfish-network": "^0.22.0",
+        "@defichain/jellyfish-transaction": "^0.22.0",
         "bs58": "^4.0.1"
       }
     },
     "node_modules/@defichain/jellyfish-api-core": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-api-core/-/jellyfish-api-core-0.18.0.tgz",
-      "integrity": "sha512-09DtWgw2/7UTX1Hd+qLr3VDbO5ssuzA811T7XFDyefXe4SDIkzXNI5CVHNfVXxR6EADH+SoXCJ+V5F3SfdjJsQ==",
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-api-core/-/jellyfish-api-core-0.22.0.tgz",
+      "integrity": "sha512-Fn6vFsu+ujgG8xtaFll2liP8oGtqhTxbjEk86VeOXEV7I5VT7XD7uI/GJyt72wLTheOBwDLEL/nPuC4QmykrOg==",
       "dependencies": {
-        "@defichain/jellyfish-json": "^0.18.0"
+        "@defichain/jellyfish-json": "^0.22.0"
       }
     },
     "node_modules/@defichain/jellyfish-api-jsonrpc": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-api-jsonrpc/-/jellyfish-api-jsonrpc-0.18.0.tgz",
-      "integrity": "sha512-jv3wVyE48OXTAt51bwyG1pTQgZbJbn3H+EXvRMMZ1d43Oycb4K6WWErgZr/xAUvPRh1QuPT/2mrgxIxfTqIohg==",
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-api-jsonrpc/-/jellyfish-api-jsonrpc-0.22.0.tgz",
+      "integrity": "sha512-hoViSHp6R62sSN2957jnfiQPMlO99FydvnpofUxcxdq5KlqIHKJfqSk/ljM26M/SiLpymItsQLOd7ek3gHPFRg==",
       "dev": true,
       "dependencies": {
-        "@defichain/jellyfish-api-core": "^0.18.0",
+        "@defichain/jellyfish-api-core": "^0.22.0",
         "abort-controller": "^3.0.0",
         "cross-fetch": "^3.1.2"
       }
     },
     "node_modules/@defichain/jellyfish-crypto": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-crypto/-/jellyfish-crypto-0.18.0.tgz",
-      "integrity": "sha512-yfQk5+GRRuXdYSMwbJYSHj2r3s5K9hDjmp4iuXyD04qQvN7EtgCOdxiM/10n60SCJb/CDCqYpFSwNqhk+5LW1Q==",
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-crypto/-/jellyfish-crypto-0.22.0.tgz",
+      "integrity": "sha512-z//t95bEE4a/PHvma/QKKY5PbOMxF4CYJHm4eiN60fRhD7xffYz6RZs6XqvAQVYxbejhMVaFRC/AhCRA6BGxfw==",
       "dependencies": {
         "bech32": "^2.0.0",
         "bip66": "^1.1.5",
@@ -571,9 +571,9 @@
       }
     },
     "node_modules/@defichain/jellyfish-json": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-json/-/jellyfish-json-0.18.0.tgz",
-      "integrity": "sha512-3hRi74+L1zRksAqZlFPhe5a2EH6hdFOcoI71YCQtuM8JIvXCJM/KZrziJQXsaApD5LGvEMbVh46ka4nZ33cdzA==",
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-json/-/jellyfish-json-0.22.0.tgz",
+      "integrity": "sha512-JH0lqhGFfbH3WbegtJOQYcmHAPnCPe1xzm8LTk1WmnzeAAmTdvac4ABDkwtg2VnoepzcLzna0VWUKidX/XqLIg==",
       "dependencies": {
         "@types/lossless-json": "^1.0.0",
         "lossless-json": "^1.0.4"
@@ -583,15 +583,16 @@
       }
     },
     "node_modules/@defichain/jellyfish-network": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-network/-/jellyfish-network-0.18.0.tgz",
-      "integrity": "sha512-Vz52N0izhiV2p8TePwkCibP39fWvEpmcq0RkjLjIKsarEgOG1+6oorcUfDyKde1h9BcBeLNWnNR9SipHOskf6w=="
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-network/-/jellyfish-network-0.22.0.tgz",
+      "integrity": "sha512-iLpkyeyLBKIuYQUq+284dSAgl8ppe8icEogEY4mG3A8QHDhmAE0MJdFp8ckF/2SjdIkV49iWu6MPNfcF9qjgNA=="
     },
     "node_modules/@defichain/jellyfish-transaction": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-transaction/-/jellyfish-transaction-0.18.0.tgz",
-      "integrity": "sha512-oAPblr8ubrAKa4OQqYkRo+CKM3PAIY2qvy8hRSgS3Kr8U/0jVwIZIBviAvddaTziP0ND4DG99dhZ1uJUWoDgTw==",
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-transaction/-/jellyfish-transaction-0.22.0.tgz",
+      "integrity": "sha512-feNTv6EtW54IOStFYi3hGB0TcYzkt7zZ3V62soTUzeyojIHvTWCtUJnRT4oQcQiMQJkIRXlbVH6FbI5SFkaT8g==",
       "dependencies": {
+        "@defichain/jellyfish-crypto": "^0.22.0",
         "smart-buffer": "^4.1.0"
       },
       "peerDependencies": {
@@ -599,25 +600,25 @@
       }
     },
     "node_modules/@defichain/jellyfish-transaction-builder": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-transaction-builder/-/jellyfish-transaction-builder-0.18.0.tgz",
-      "integrity": "sha512-DqIv1rk3iAUnsf/6XKQ2xZtDFE93CemRMl0SjwItSiNgFFhC12tuSwGrBfYpJIvcW7aMJ3T03Rtr7cJ5bd8cCg==",
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-transaction-builder/-/jellyfish-transaction-builder-0.22.0.tgz",
+      "integrity": "sha512-mok4fAnoFW99q1molE3ss36aaHYOo2ugbLJDT5OzzoJMz0vLIgM7wxmEzIWu7hgR6KsL/AU9MkJFN11QpOcnHg==",
       "dependencies": {
-        "@defichain/jellyfish-crypto": "^0.18.0",
-        "@defichain/jellyfish-transaction": "^0.18.0",
-        "@defichain/jellyfish-transaction-signature": "^0.18.0"
+        "@defichain/jellyfish-crypto": "^0.22.0",
+        "@defichain/jellyfish-transaction": "^0.22.0",
+        "@defichain/jellyfish-transaction-signature": "^0.22.0"
       },
       "peerDependencies": {
         "bignumber.js": "^9.0.1"
       }
     },
     "node_modules/@defichain/jellyfish-transaction-signature": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-transaction-signature/-/jellyfish-transaction-signature-0.18.0.tgz",
-      "integrity": "sha512-KnNUyNLhgOf1BMBk7qltpdghQ8Fxq0tuqFT5vbL+mXzRSCD4wI5bRs2k6Ums0EFyTiB4jHCVtVqOw1Fb9C/Dvg==",
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-transaction-signature/-/jellyfish-transaction-signature-0.22.0.tgz",
+      "integrity": "sha512-+ilAcorkCCVpJ+aeN6bJ+Eve2c6A6TisJkC+RZdGYo/gGjtGVSInaZ0qwJh01Cx/ce06XRqkL5b+1WQTjajnCQ==",
       "dependencies": {
-        "@defichain/jellyfish-crypto": "^0.18.0",
-        "@defichain/jellyfish-transaction": "^0.18.0",
+        "@defichain/jellyfish-crypto": "^0.22.0",
+        "@defichain/jellyfish-transaction": "^0.22.0",
         "smart-buffer": "^4.1.0"
       },
       "peerDependencies": {
@@ -625,14 +626,14 @@
       }
     },
     "node_modules/@defichain/jellyfish-wallet": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-wallet/-/jellyfish-wallet-0.18.0.tgz",
-      "integrity": "sha512-qUmYPiO79aqUXLmAV4f0Fa65BK5yo5WcXFpOD4TbVlLaXgLSEJh9evf7qyqh+8EGnEk1/gUNVDrpStNClE6+Gw==",
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-wallet/-/jellyfish-wallet-0.22.0.tgz",
+      "integrity": "sha512-3BGgmVDBo4ZKUgGYX8P+F9c9DTxAS1CVzEgL/mLI816Nas3pkyBEL4nO764bu1+lrHEqGVi58BVF/7mQw4Z1ig==",
       "dependencies": {
-        "@defichain/jellyfish-address": "^0.18.0",
-        "@defichain/jellyfish-crypto": "^0.18.0",
-        "@defichain/jellyfish-transaction": "^0.18.0",
-        "@defichain/jellyfish-transaction-signature": "^0.18.0"
+        "@defichain/jellyfish-address": "^0.22.0",
+        "@defichain/jellyfish-crypto": "^0.22.0",
+        "@defichain/jellyfish-network": "^0.22.0",
+        "@defichain/jellyfish-transaction": "^0.22.0"
       },
       "peerDependencies": {
         "bignumber.js": "^9.0.1"
@@ -663,9 +664,9 @@
       "link": true
     },
     "node_modules/@defichain/testcontainers": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@defichain/testcontainers/-/testcontainers-0.18.0.tgz",
-      "integrity": "sha512-UjCqFoIKgNmLJUjVS8HeOwGZR1EGtva/Jo3VBVL60IWX8pjO9vnK5tcZZnwePL9uyUB/BvDXMO2t7homWWOrmw==",
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@defichain/testcontainers/-/testcontainers-0.22.0.tgz",
+      "integrity": "sha512-uVb5SSFHo0IXeiRI/SiwJyGb6gMd0O7iu5FMBEJiqSYxbclUBBtBcQgCjvl1SAPYLVSCiNXnur+O/mOWnk7KAQ==",
       "dev": true,
       "dependencies": {
         "dockerode": "^3.3.0",
@@ -673,36 +674,36 @@
       }
     },
     "node_modules/@defichain/testing": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@defichain/testing/-/testing-0.18.0.tgz",
-      "integrity": "sha512-+ztGgVIwPirBrWE53LBYrel8/Yf7JhQ83C1Tc9cH7vyn8X+tsUZWLLaeF+pi40Z3JkmYApIr4K6Fr/NR5l6xnA==",
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@defichain/testing/-/testing-0.22.0.tgz",
+      "integrity": "sha512-mMn/eT208OFp0VwEpqEpAGunHv6A0DF4mutELiboOQPgil5ifQFtt36KJBq194heOfZWwvCU9hWkpIRDmLp6Ew==",
       "dev": true,
       "dependencies": {
-        "@defichain/jellyfish-api-core": "^0.18.0",
-        "@defichain/jellyfish-crypto": "^0.18.0",
-        "@defichain/jellyfish-network": "^0.18.0",
-        "@defichain/testcontainers": "^0.18.0"
+        "@defichain/jellyfish-api-core": "^0.22.0",
+        "@defichain/jellyfish-crypto": "^0.22.0",
+        "@defichain/jellyfish-network": "^0.22.0",
+        "@defichain/testcontainers": "^0.22.0"
       }
     },
     "node_modules/@defichain/whale-api-client": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@defichain/whale-api-client/-/whale-api-client-0.4.0.tgz",
-      "integrity": "sha512-70qQ77KgNXICC6f1+zE2i1qRohYxv70E9ueyGageOoMADRaoZMnuCYuI2N74tUZXQrmQCUQwBTupmv15Xb2a7Q==",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@defichain/whale-api-client/-/whale-api-client-0.5.5.tgz",
+      "integrity": "sha512-AFJrtRd3KbfuA0VET9V92Kg1Cui2Sjoo6pZg8V7c1FNz43n4+KvpmcuCirb2j1JXA2bvHJP73jWYAv97m9hWug==",
       "dependencies": {
-        "@defichain/jellyfish-api-core": ">=0.17.0",
+        "@defichain/jellyfish-api-core": ">=0.22.0",
         "abort-controller": "^3.0.0",
         "cross-fetch": "^3.1.2",
         "url-search-params-polyfill": "8.1.1"
       }
     },
     "node_modules/@defichain/whale-api-wallet": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@defichain/whale-api-wallet/-/whale-api-wallet-0.4.0.tgz",
-      "integrity": "sha512-6yEt+V8r8odV4b26FAo4jMwwoMdVLFfpirakhHF0dWiCp1OWUZvr+JHIufhzbLFt4x6UvWAsiAEVc5BBhIa4Nw==",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@defichain/whale-api-wallet/-/whale-api-wallet-0.5.5.tgz",
+      "integrity": "sha512-coSMWH3goizHsGGjlTlQBK2XkitMyzVj71FvL7nphkdQ2qtycE4rjPCuoX3+pTwgJLMUXEVRNhQy7PEx5XdSfA==",
       "dependencies": {
-        "@defichain/jellyfish-transaction-builder": ">=0.17.0",
-        "@defichain/jellyfish-wallet": ">=0.17.0",
-        "@defichain/whale-api-client": "^0.4.0"
+        "@defichain/jellyfish-transaction-builder": ">=0.22.0",
+        "@defichain/jellyfish-wallet": ">=0.22.0",
+        "@defichain/whale-api-client": "^0.5.5"
       }
     },
     "node_modules/@eslint/eslintrc": {
@@ -15129,9 +15130,9 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@defichain/jellyfish-crypto": ">=0.18.0",
-        "@defichain/jellyfish-transaction": ">=0.18.0",
-        "@defichain/jellyfish-transaction-builder": ">=0.18.0",
+        "@defichain/jellyfish-crypto": ">=0.22.0",
+        "@defichain/jellyfish-transaction": ">=0.22.0",
+        "@defichain/jellyfish-transaction-builder": ">=0.22.0",
         "@defichain/salmon-oracles-functions": "0.0.0",
         "@defichain/salmon-price-functions": "0.0.0",
         "@defichain/salmon-provider-finnhubb": "0.0.0",
@@ -15139,9 +15140,9 @@
         "@defichain/salmon-provider-tiingo": "0.0.0"
       },
       "devDependencies": {
-        "@defichain/jellyfish-api-jsonrpc": ">=0.18.0",
-        "@defichain/testcontainers": ">=0.18.0",
-        "@defichain/testing": ">=0.18.0",
+        "@defichain/jellyfish-api-jsonrpc": ">=0.22.0",
+        "@defichain/testcontainers": ">=0.22.0",
+        "@defichain/testing": ">=0.22.0",
         "@vercel/ncc": "^0.28.6",
         "aws-sdk": "^2.936.0"
       },
@@ -15150,9 +15151,9 @@
       }
     },
     "packages/salmon-lambda-functions/node_modules/@defichain/jellyfish-crypto": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-crypto/-/jellyfish-crypto-0.18.0.tgz",
-      "integrity": "sha512-yfQk5+GRRuXdYSMwbJYSHj2r3s5K9hDjmp4iuXyD04qQvN7EtgCOdxiM/10n60SCJb/CDCqYpFSwNqhk+5LW1Q==",
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-crypto/-/jellyfish-crypto-0.22.0.tgz",
+      "integrity": "sha512-z//t95bEE4a/PHvma/QKKY5PbOMxF4CYJHm4eiN60fRhD7xffYz6RZs6XqvAQVYxbejhMVaFRC/AhCRA6BGxfw==",
       "dependencies": {
         "bech32": "^2.0.0",
         "bip66": "^1.1.5",
@@ -15165,10 +15166,11 @@
       }
     },
     "packages/salmon-lambda-functions/node_modules/@defichain/jellyfish-transaction": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-transaction/-/jellyfish-transaction-0.18.0.tgz",
-      "integrity": "sha512-oAPblr8ubrAKa4OQqYkRo+CKM3PAIY2qvy8hRSgS3Kr8U/0jVwIZIBviAvddaTziP0ND4DG99dhZ1uJUWoDgTw==",
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-transaction/-/jellyfish-transaction-0.22.0.tgz",
+      "integrity": "sha512-feNTv6EtW54IOStFYi3hGB0TcYzkt7zZ3V62soTUzeyojIHvTWCtUJnRT4oQcQiMQJkIRXlbVH6FbI5SFkaT8g==",
       "dependencies": {
+        "@defichain/jellyfish-crypto": "^0.22.0",
         "smart-buffer": "^4.1.0"
       },
       "peerDependencies": {
@@ -15176,9 +15178,9 @@
       }
     },
     "packages/salmon-lambda-functions/node_modules/@defichain/testcontainers": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@defichain/testcontainers/-/testcontainers-0.18.0.tgz",
-      "integrity": "sha512-UjCqFoIKgNmLJUjVS8HeOwGZR1EGtva/Jo3VBVL60IWX8pjO9vnK5tcZZnwePL9uyUB/BvDXMO2t7homWWOrmw==",
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@defichain/testcontainers/-/testcontainers-0.22.0.tgz",
+      "integrity": "sha512-uVb5SSFHo0IXeiRI/SiwJyGb6gMd0O7iu5FMBEJiqSYxbclUBBtBcQgCjvl1SAPYLVSCiNXnur+O/mOWnk7KAQ==",
       "dev": true,
       "dependencies": {
         "dockerode": "^3.3.0",
@@ -15190,17 +15192,55 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@defichain/jellyfish-crypto": ">=0.18.0",
-        "@defichain/jellyfish-transaction": ">=0.18.0",
-        "@defichain/jellyfish-transaction-builder": ">=0.18.0",
-        "@defichain/jellyfish-wallet": ">=0.18.0",
-        "@defichain/whale-api-client": ">=0.4.0",
-        "@defichain/whale-api-wallet": ">=0.4.0",
+        "@defichain/jellyfish-crypto": ">=0.22.0",
+        "@defichain/jellyfish-transaction": ">=0.22.0",
+        "@defichain/jellyfish-transaction-builder": ">=0.22.0",
+        "@defichain/jellyfish-wallet": ">=0.22.0",
+        "@defichain/whale-api-client": ">=0.5.5",
+        "@defichain/whale-api-wallet": ">=0.5.5",
         "bignumber.js": "^9.0.1"
       },
       "devDependencies": {
-        "@defichain/testcontainers": ">=0.18.0",
-        "@defichain/testing": ">=0.18.0"
+        "@defichain/testcontainers": ">=0.22.0",
+        "@defichain/testing": ">=0.22.0"
+      }
+    },
+    "packages/salmon-oracles-functions/node_modules/@defichain/jellyfish-crypto": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-crypto/-/jellyfish-crypto-0.22.0.tgz",
+      "integrity": "sha512-z//t95bEE4a/PHvma/QKKY5PbOMxF4CYJHm4eiN60fRhD7xffYz6RZs6XqvAQVYxbejhMVaFRC/AhCRA6BGxfw==",
+      "dependencies": {
+        "bech32": "^2.0.0",
+        "bip66": "^1.1.5",
+        "browserify-aes": "^1.2.0",
+        "bs58": "^4.0.1",
+        "create-hash": "^1.2.0",
+        "randombytes": "^2.1.0",
+        "tiny-secp256k1": "^1.1.6",
+        "wif": "^2.0.6"
+      }
+    },
+    "packages/salmon-oracles-functions/node_modules/@defichain/jellyfish-transaction": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-transaction/-/jellyfish-transaction-0.22.0.tgz",
+      "integrity": "sha512-feNTv6EtW54IOStFYi3hGB0TcYzkt7zZ3V62soTUzeyojIHvTWCtUJnRT4oQcQiMQJkIRXlbVH6FbI5SFkaT8g==",
+      "dependencies": {
+        "@defichain/jellyfish-crypto": "^0.22.0",
+        "smart-buffer": "^4.1.0"
+      },
+      "peerDependencies": {
+        "bignumber.js": "^9.0.1"
+      }
+    },
+    "packages/salmon-oracles-functions/node_modules/@defichain/whale-api-client": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@defichain/whale-api-client/-/whale-api-client-0.5.5.tgz",
+      "integrity": "sha512-AFJrtRd3KbfuA0VET9V92Kg1Cui2Sjoo6pZg8V7c1FNz43n4+KvpmcuCirb2j1JXA2bvHJP73jWYAv97m9hWug==",
+      "dependencies": {
+        "@defichain/jellyfish-api-core": ">=0.22.0",
+        "abort-controller": "^3.0.0",
+        "cross-fetch": "^3.1.2",
+        "url-search-params-polyfill": "8.1.1"
       }
     },
     "packages/salmon-price-functions": {
@@ -15208,8 +15248,8 @@
       "version": "0.0.0",
       "license": "MIT",
       "devDependencies": {
-        "@defichain/testcontainers": ">=0.18.0",
-        "@defichain/testing": ">=0.18.0",
+        "@defichain/testcontainers": ">=0.22.0",
+        "@defichain/testing": ">=0.22.0",
         "@types/lossless-json": "^1.0.0"
       },
       "peerDependencies": {
@@ -15699,39 +15739,39 @@
       }
     },
     "@defichain/jellyfish-address": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-address/-/jellyfish-address-0.18.0.tgz",
-      "integrity": "sha512-xUBHTuBY3Ly8NOWjcjuOMeokIiPC7+6A8fx9xedJKJL5kn+RamPW9pl6HjUhr4RdUFTZ15GhSk0VZ67O3NIM4g==",
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-address/-/jellyfish-address-0.22.0.tgz",
+      "integrity": "sha512-NqlONt0Vkp5nmvg3glxmDWy7boZdyal5/wP55FNJEyDfS4IxpA3sv+GYIDJe2M/u4HFud/lEm6sPnjyT466y4A==",
       "requires": {
-        "@defichain/jellyfish-crypto": "^0.18.0",
-        "@defichain/jellyfish-network": "^0.18.0",
-        "@defichain/jellyfish-transaction": "^0.18.0",
+        "@defichain/jellyfish-crypto": "^0.22.0",
+        "@defichain/jellyfish-network": "^0.22.0",
+        "@defichain/jellyfish-transaction": "^0.22.0",
         "bs58": "^4.0.1"
       }
     },
     "@defichain/jellyfish-api-core": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-api-core/-/jellyfish-api-core-0.18.0.tgz",
-      "integrity": "sha512-09DtWgw2/7UTX1Hd+qLr3VDbO5ssuzA811T7XFDyefXe4SDIkzXNI5CVHNfVXxR6EADH+SoXCJ+V5F3SfdjJsQ==",
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-api-core/-/jellyfish-api-core-0.22.0.tgz",
+      "integrity": "sha512-Fn6vFsu+ujgG8xtaFll2liP8oGtqhTxbjEk86VeOXEV7I5VT7XD7uI/GJyt72wLTheOBwDLEL/nPuC4QmykrOg==",
       "requires": {
-        "@defichain/jellyfish-json": "^0.18.0"
+        "@defichain/jellyfish-json": "^0.22.0"
       }
     },
     "@defichain/jellyfish-api-jsonrpc": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-api-jsonrpc/-/jellyfish-api-jsonrpc-0.18.0.tgz",
-      "integrity": "sha512-jv3wVyE48OXTAt51bwyG1pTQgZbJbn3H+EXvRMMZ1d43Oycb4K6WWErgZr/xAUvPRh1QuPT/2mrgxIxfTqIohg==",
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-api-jsonrpc/-/jellyfish-api-jsonrpc-0.22.0.tgz",
+      "integrity": "sha512-hoViSHp6R62sSN2957jnfiQPMlO99FydvnpofUxcxdq5KlqIHKJfqSk/ljM26M/SiLpymItsQLOd7ek3gHPFRg==",
       "dev": true,
       "requires": {
-        "@defichain/jellyfish-api-core": "^0.18.0",
+        "@defichain/jellyfish-api-core": "^0.22.0",
         "abort-controller": "^3.0.0",
         "cross-fetch": "^3.1.2"
       }
     },
     "@defichain/jellyfish-crypto": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-crypto/-/jellyfish-crypto-0.18.0.tgz",
-      "integrity": "sha512-yfQk5+GRRuXdYSMwbJYSHj2r3s5K9hDjmp4iuXyD04qQvN7EtgCOdxiM/10n60SCJb/CDCqYpFSwNqhk+5LW1Q==",
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-crypto/-/jellyfish-crypto-0.22.0.tgz",
+      "integrity": "sha512-z//t95bEE4a/PHvma/QKKY5PbOMxF4CYJHm4eiN60fRhD7xffYz6RZs6XqvAQVYxbejhMVaFRC/AhCRA6BGxfw==",
       "requires": {
         "bech32": "^2.0.0",
         "bip66": "^1.1.5",
@@ -15744,80 +15784,81 @@
       }
     },
     "@defichain/jellyfish-json": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-json/-/jellyfish-json-0.18.0.tgz",
-      "integrity": "sha512-3hRi74+L1zRksAqZlFPhe5a2EH6hdFOcoI71YCQtuM8JIvXCJM/KZrziJQXsaApD5LGvEMbVh46ka4nZ33cdzA==",
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-json/-/jellyfish-json-0.22.0.tgz",
+      "integrity": "sha512-JH0lqhGFfbH3WbegtJOQYcmHAPnCPe1xzm8LTk1WmnzeAAmTdvac4ABDkwtg2VnoepzcLzna0VWUKidX/XqLIg==",
       "requires": {
         "@types/lossless-json": "^1.0.0",
         "lossless-json": "^1.0.4"
       }
     },
     "@defichain/jellyfish-network": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-network/-/jellyfish-network-0.18.0.tgz",
-      "integrity": "sha512-Vz52N0izhiV2p8TePwkCibP39fWvEpmcq0RkjLjIKsarEgOG1+6oorcUfDyKde1h9BcBeLNWnNR9SipHOskf6w=="
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-network/-/jellyfish-network-0.22.0.tgz",
+      "integrity": "sha512-iLpkyeyLBKIuYQUq+284dSAgl8ppe8icEogEY4mG3A8QHDhmAE0MJdFp8ckF/2SjdIkV49iWu6MPNfcF9qjgNA=="
     },
     "@defichain/jellyfish-transaction": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-transaction/-/jellyfish-transaction-0.18.0.tgz",
-      "integrity": "sha512-oAPblr8ubrAKa4OQqYkRo+CKM3PAIY2qvy8hRSgS3Kr8U/0jVwIZIBviAvddaTziP0ND4DG99dhZ1uJUWoDgTw==",
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-transaction/-/jellyfish-transaction-0.22.0.tgz",
+      "integrity": "sha512-feNTv6EtW54IOStFYi3hGB0TcYzkt7zZ3V62soTUzeyojIHvTWCtUJnRT4oQcQiMQJkIRXlbVH6FbI5SFkaT8g==",
       "requires": {
+        "@defichain/jellyfish-crypto": "^0.22.0",
         "smart-buffer": "^4.1.0"
       }
     },
     "@defichain/jellyfish-transaction-builder": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-transaction-builder/-/jellyfish-transaction-builder-0.18.0.tgz",
-      "integrity": "sha512-DqIv1rk3iAUnsf/6XKQ2xZtDFE93CemRMl0SjwItSiNgFFhC12tuSwGrBfYpJIvcW7aMJ3T03Rtr7cJ5bd8cCg==",
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-transaction-builder/-/jellyfish-transaction-builder-0.22.0.tgz",
+      "integrity": "sha512-mok4fAnoFW99q1molE3ss36aaHYOo2ugbLJDT5OzzoJMz0vLIgM7wxmEzIWu7hgR6KsL/AU9MkJFN11QpOcnHg==",
       "requires": {
-        "@defichain/jellyfish-crypto": "^0.18.0",
-        "@defichain/jellyfish-transaction": "^0.18.0",
-        "@defichain/jellyfish-transaction-signature": "^0.18.0"
+        "@defichain/jellyfish-crypto": "^0.22.0",
+        "@defichain/jellyfish-transaction": "^0.22.0",
+        "@defichain/jellyfish-transaction-signature": "^0.22.0"
       }
     },
     "@defichain/jellyfish-transaction-signature": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-transaction-signature/-/jellyfish-transaction-signature-0.18.0.tgz",
-      "integrity": "sha512-KnNUyNLhgOf1BMBk7qltpdghQ8Fxq0tuqFT5vbL+mXzRSCD4wI5bRs2k6Ums0EFyTiB4jHCVtVqOw1Fb9C/Dvg==",
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-transaction-signature/-/jellyfish-transaction-signature-0.22.0.tgz",
+      "integrity": "sha512-+ilAcorkCCVpJ+aeN6bJ+Eve2c6A6TisJkC+RZdGYo/gGjtGVSInaZ0qwJh01Cx/ce06XRqkL5b+1WQTjajnCQ==",
       "requires": {
-        "@defichain/jellyfish-crypto": "^0.18.0",
-        "@defichain/jellyfish-transaction": "^0.18.0",
+        "@defichain/jellyfish-crypto": "^0.22.0",
+        "@defichain/jellyfish-transaction": "^0.22.0",
         "smart-buffer": "^4.1.0"
       }
     },
     "@defichain/jellyfish-wallet": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-wallet/-/jellyfish-wallet-0.18.0.tgz",
-      "integrity": "sha512-qUmYPiO79aqUXLmAV4f0Fa65BK5yo5WcXFpOD4TbVlLaXgLSEJh9evf7qyqh+8EGnEk1/gUNVDrpStNClE6+Gw==",
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-wallet/-/jellyfish-wallet-0.22.0.tgz",
+      "integrity": "sha512-3BGgmVDBo4ZKUgGYX8P+F9c9DTxAS1CVzEgL/mLI816Nas3pkyBEL4nO764bu1+lrHEqGVi58BVF/7mQw4Z1ig==",
       "requires": {
-        "@defichain/jellyfish-address": "^0.18.0",
-        "@defichain/jellyfish-crypto": "^0.18.0",
-        "@defichain/jellyfish-transaction": "^0.18.0",
-        "@defichain/jellyfish-transaction-signature": "^0.18.0"
+        "@defichain/jellyfish-address": "^0.22.0",
+        "@defichain/jellyfish-crypto": "^0.22.0",
+        "@defichain/jellyfish-network": "^0.22.0",
+        "@defichain/jellyfish-transaction": "^0.22.0"
       }
     },
     "@defichain/salmon-lambda-functions": {
       "version": "file:packages/salmon-lambda-functions",
       "requires": {
-        "@defichain/jellyfish-api-jsonrpc": ">=0.18.0",
-        "@defichain/jellyfish-crypto": ">=0.18.0",
-        "@defichain/jellyfish-transaction": ">=0.18.0",
-        "@defichain/jellyfish-transaction-builder": ">=0.18.0",
+        "@defichain/jellyfish-api-jsonrpc": ">=0.22.0",
+        "@defichain/jellyfish-crypto": ">=0.22.0",
+        "@defichain/jellyfish-transaction": ">=0.22.0",
+        "@defichain/jellyfish-transaction-builder": ">=0.22.0",
         "@defichain/salmon-oracles-functions": "0.0.0",
         "@defichain/salmon-price-functions": "0.0.0",
         "@defichain/salmon-provider-finnhubb": "0.0.0",
         "@defichain/salmon-provider-iexcloud": "0.0.0",
         "@defichain/salmon-provider-tiingo": "0.0.0",
-        "@defichain/testcontainers": ">=0.18.0",
-        "@defichain/testing": ">=0.18.0",
+        "@defichain/testcontainers": ">=0.22.0",
+        "@defichain/testing": ">=0.22.0",
         "@vercel/ncc": "^0.28.6",
         "aws-sdk": "^2.936.0"
       },
       "dependencies": {
         "@defichain/jellyfish-crypto": {
-          "version": "0.18.0",
-          "resolved": "https://registry.npmjs.org/@defichain/jellyfish-crypto/-/jellyfish-crypto-0.18.0.tgz",
-          "integrity": "sha512-yfQk5+GRRuXdYSMwbJYSHj2r3s5K9hDjmp4iuXyD04qQvN7EtgCOdxiM/10n60SCJb/CDCqYpFSwNqhk+5LW1Q==",
+          "version": "0.22.0",
+          "resolved": "https://registry.npmjs.org/@defichain/jellyfish-crypto/-/jellyfish-crypto-0.22.0.tgz",
+          "integrity": "sha512-z//t95bEE4a/PHvma/QKKY5PbOMxF4CYJHm4eiN60fRhD7xffYz6RZs6XqvAQVYxbejhMVaFRC/AhCRA6BGxfw==",
           "requires": {
             "bech32": "^2.0.0",
             "bip66": "^1.1.5",
@@ -15830,17 +15871,18 @@
           }
         },
         "@defichain/jellyfish-transaction": {
-          "version": "0.18.0",
-          "resolved": "https://registry.npmjs.org/@defichain/jellyfish-transaction/-/jellyfish-transaction-0.18.0.tgz",
-          "integrity": "sha512-oAPblr8ubrAKa4OQqYkRo+CKM3PAIY2qvy8hRSgS3Kr8U/0jVwIZIBviAvddaTziP0ND4DG99dhZ1uJUWoDgTw==",
+          "version": "0.22.0",
+          "resolved": "https://registry.npmjs.org/@defichain/jellyfish-transaction/-/jellyfish-transaction-0.22.0.tgz",
+          "integrity": "sha512-feNTv6EtW54IOStFYi3hGB0TcYzkt7zZ3V62soTUzeyojIHvTWCtUJnRT4oQcQiMQJkIRXlbVH6FbI5SFkaT8g==",
           "requires": {
+            "@defichain/jellyfish-crypto": "^0.22.0",
             "smart-buffer": "^4.1.0"
           }
         },
         "@defichain/testcontainers": {
-          "version": "0.18.0",
-          "resolved": "https://registry.npmjs.org/@defichain/testcontainers/-/testcontainers-0.18.0.tgz",
-          "integrity": "sha512-UjCqFoIKgNmLJUjVS8HeOwGZR1EGtva/Jo3VBVL60IWX8pjO9vnK5tcZZnwePL9uyUB/BvDXMO2t7homWWOrmw==",
+          "version": "0.22.0",
+          "resolved": "https://registry.npmjs.org/@defichain/testcontainers/-/testcontainers-0.22.0.tgz",
+          "integrity": "sha512-uVb5SSFHo0IXeiRI/SiwJyGb6gMd0O7iu5FMBEJiqSYxbclUBBtBcQgCjvl1SAPYLVSCiNXnur+O/mOWnk7KAQ==",
           "dev": true,
           "requires": {
             "dockerode": "^3.3.0",
@@ -15852,22 +15894,59 @@
     "@defichain/salmon-oracles-functions": {
       "version": "file:packages/salmon-oracles-functions",
       "requires": {
-        "@defichain/jellyfish-crypto": ">=0.18.0",
-        "@defichain/jellyfish-transaction": ">=0.18.0",
-        "@defichain/jellyfish-transaction-builder": ">=0.18.0",
-        "@defichain/jellyfish-wallet": ">=0.18.0",
-        "@defichain/testcontainers": ">=0.18.0",
-        "@defichain/testing": ">=0.18.0",
-        "@defichain/whale-api-client": ">=0.4.0",
-        "@defichain/whale-api-wallet": ">=0.4.0",
+        "@defichain/jellyfish-crypto": ">=0.22.0",
+        "@defichain/jellyfish-transaction": ">=0.22.0",
+        "@defichain/jellyfish-transaction-builder": ">=0.22.0",
+        "@defichain/jellyfish-wallet": ">=0.22.0",
+        "@defichain/testcontainers": ">=0.22.0",
+        "@defichain/testing": ">=0.22.0",
+        "@defichain/whale-api-client": ">=0.5.5",
+        "@defichain/whale-api-wallet": ">=0.5.5",
         "bignumber.js": "^9.0.1"
+      },
+      "dependencies": {
+        "@defichain/jellyfish-crypto": {
+          "version": "0.22.0",
+          "resolved": "https://registry.npmjs.org/@defichain/jellyfish-crypto/-/jellyfish-crypto-0.22.0.tgz",
+          "integrity": "sha512-z//t95bEE4a/PHvma/QKKY5PbOMxF4CYJHm4eiN60fRhD7xffYz6RZs6XqvAQVYxbejhMVaFRC/AhCRA6BGxfw==",
+          "requires": {
+            "bech32": "^2.0.0",
+            "bip66": "^1.1.5",
+            "browserify-aes": "^1.2.0",
+            "bs58": "^4.0.1",
+            "create-hash": "^1.2.0",
+            "randombytes": "^2.1.0",
+            "tiny-secp256k1": "^1.1.6",
+            "wif": "^2.0.6"
+          }
+        },
+        "@defichain/jellyfish-transaction": {
+          "version": "0.22.0",
+          "resolved": "https://registry.npmjs.org/@defichain/jellyfish-transaction/-/jellyfish-transaction-0.22.0.tgz",
+          "integrity": "sha512-feNTv6EtW54IOStFYi3hGB0TcYzkt7zZ3V62soTUzeyojIHvTWCtUJnRT4oQcQiMQJkIRXlbVH6FbI5SFkaT8g==",
+          "requires": {
+            "@defichain/jellyfish-crypto": "^0.22.0",
+            "smart-buffer": "^4.1.0"
+          }
+        },
+        "@defichain/whale-api-client": {
+          "version": "0.5.5",
+          "resolved": "https://registry.npmjs.org/@defichain/whale-api-client/-/whale-api-client-0.5.5.tgz",
+          "integrity": "sha512-AFJrtRd3KbfuA0VET9V92Kg1Cui2Sjoo6pZg8V7c1FNz43n4+KvpmcuCirb2j1JXA2bvHJP73jWYAv97m9hWug==",
+          "requires": {
+            "@defichain/jellyfish-api-core": ">=0.22.0",
+            "abort-controller": "^3.0.0",
+            "cross-fetch": "^3.1.2",
+            "url-search-params-polyfill": "8.1.1"
+          }
+        }
       }
     },
     "@defichain/salmon-price-functions": {
       "version": "file:packages/salmon-price-functions",
       "requires": {
-        "@defichain/testcontainers": ">=0.18.0",
-        "@defichain/testing": ">=0.18.0",
+        "@defichain/testcontainers": ">=0.22.0",
+        "@defichain/testing": ">=0.22.0",
         "@types/lossless-json": "^1.0.0"
       }
     },
@@ -15902,9 +15981,9 @@
       }
     },
     "@defichain/testcontainers": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@defichain/testcontainers/-/testcontainers-0.18.0.tgz",
-      "integrity": "sha512-UjCqFoIKgNmLJUjVS8HeOwGZR1EGtva/Jo3VBVL60IWX8pjO9vnK5tcZZnwePL9uyUB/BvDXMO2t7homWWOrmw==",
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@defichain/testcontainers/-/testcontainers-0.22.0.tgz",
+      "integrity": "sha512-uVb5SSFHo0IXeiRI/SiwJyGb6gMd0O7iu5FMBEJiqSYxbclUBBtBcQgCjvl1SAPYLVSCiNXnur+O/mOWnk7KAQ==",
       "dev": true,
       "requires": {
         "dockerode": "^3.3.0",
@@ -15912,36 +15991,36 @@
       }
     },
     "@defichain/testing": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@defichain/testing/-/testing-0.18.0.tgz",
-      "integrity": "sha512-+ztGgVIwPirBrWE53LBYrel8/Yf7JhQ83C1Tc9cH7vyn8X+tsUZWLLaeF+pi40Z3JkmYApIr4K6Fr/NR5l6xnA==",
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@defichain/testing/-/testing-0.22.0.tgz",
+      "integrity": "sha512-mMn/eT208OFp0VwEpqEpAGunHv6A0DF4mutELiboOQPgil5ifQFtt36KJBq194heOfZWwvCU9hWkpIRDmLp6Ew==",
       "dev": true,
       "requires": {
-        "@defichain/jellyfish-api-core": "^0.18.0",
-        "@defichain/jellyfish-crypto": "^0.18.0",
-        "@defichain/jellyfish-network": "^0.18.0",
-        "@defichain/testcontainers": "^0.18.0"
+        "@defichain/jellyfish-api-core": "^0.22.0",
+        "@defichain/jellyfish-crypto": "^0.22.0",
+        "@defichain/jellyfish-network": "^0.22.0",
+        "@defichain/testcontainers": "^0.22.0"
       }
     },
     "@defichain/whale-api-client": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@defichain/whale-api-client/-/whale-api-client-0.4.0.tgz",
-      "integrity": "sha512-70qQ77KgNXICC6f1+zE2i1qRohYxv70E9ueyGageOoMADRaoZMnuCYuI2N74tUZXQrmQCUQwBTupmv15Xb2a7Q==",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@defichain/whale-api-client/-/whale-api-client-0.5.5.tgz",
+      "integrity": "sha512-AFJrtRd3KbfuA0VET9V92Kg1Cui2Sjoo6pZg8V7c1FNz43n4+KvpmcuCirb2j1JXA2bvHJP73jWYAv97m9hWug==",
       "requires": {
-        "@defichain/jellyfish-api-core": ">=0.17.0",
+        "@defichain/jellyfish-api-core": ">=0.22.0",
         "abort-controller": "^3.0.0",
         "cross-fetch": "^3.1.2",
         "url-search-params-polyfill": "8.1.1"
       }
     },
     "@defichain/whale-api-wallet": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@defichain/whale-api-wallet/-/whale-api-wallet-0.4.0.tgz",
-      "integrity": "sha512-6yEt+V8r8odV4b26FAo4jMwwoMdVLFfpirakhHF0dWiCp1OWUZvr+JHIufhzbLFt4x6UvWAsiAEVc5BBhIa4Nw==",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@defichain/whale-api-wallet/-/whale-api-wallet-0.5.5.tgz",
+      "integrity": "sha512-coSMWH3goizHsGGjlTlQBK2XkitMyzVj71FvL7nphkdQ2qtycE4rjPCuoX3+pTwgJLMUXEVRNhQy7PEx5XdSfA==",
       "requires": {
-        "@defichain/jellyfish-transaction-builder": ">=0.17.0",
-        "@defichain/jellyfish-wallet": ">=0.17.0",
-        "@defichain/whale-api-client": "^0.4.0"
+        "@defichain/jellyfish-transaction-builder": ">=0.22.0",
+        "@defichain/jellyfish-wallet": ">=0.22.0",
+        "@defichain/whale-api-client": "^0.5.5"
       }
     },
     "@eslint/eslintrc": {

--- a/packages/salmon-lambda-functions/package.json
+++ b/packages/salmon-lambda-functions/package.json
@@ -39,9 +39,9 @@
     "bignumber.js": "^9.0.1"
   },
   "dependencies": {
-    "@defichain/jellyfish-crypto": ">=0.18.0",
-    "@defichain/jellyfish-transaction": ">=0.18.0",
-    "@defichain/jellyfish-transaction-builder": ">=0.18.0",
+    "@defichain/jellyfish-crypto": ">=0.22.0",
+    "@defichain/jellyfish-transaction": ">=0.22.0",
+    "@defichain/jellyfish-transaction-builder": ">=0.22.0",
     "@defichain/salmon-price-functions": "0.0.0",
     "@defichain/salmon-oracles-functions": "0.0.0",
     "@defichain/salmon-provider-tiingo": "0.0.0",
@@ -49,9 +49,9 @@
     "@defichain/salmon-provider-iexcloud": "0.0.0"
   },
   "devDependencies": {
-    "@defichain/jellyfish-api-jsonrpc": ">=0.18.0",
-    "@defichain/testcontainers": ">=0.18.0",
-    "@defichain/testing": ">=0.18.0",
+    "@defichain/jellyfish-api-jsonrpc": ">=0.22.0",
+    "@defichain/testcontainers": ">=0.22.0",
+    "@defichain/testing": ">=0.22.0",
     "@vercel/ncc": "^0.28.6",
     "aws-sdk": "^2.936.0"
   }

--- a/packages/salmon-oracles-functions/package.json
+++ b/packages/salmon-oracles-functions/package.json
@@ -35,16 +35,16 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@defichain/whale-api-wallet": ">=0.4.0",
-    "@defichain/whale-api-client": ">=0.4.0",
-    "@defichain/jellyfish-wallet": ">=0.18.0",
-    "@defichain/jellyfish-crypto": ">=0.18.0",
-    "@defichain/jellyfish-transaction": ">=0.18.0",
-    "@defichain/jellyfish-transaction-builder": ">=0.18.0",
+    "@defichain/whale-api-wallet": ">=0.5.5",
+    "@defichain/whale-api-client": ">=0.5.5",
+    "@defichain/jellyfish-wallet": ">=0.22.0",
+    "@defichain/jellyfish-crypto": ">=0.22.0",
+    "@defichain/jellyfish-transaction": ">=0.22.0",
+    "@defichain/jellyfish-transaction-builder": ">=0.22.0",
     "bignumber.js": "^9.0.1"
   },
   "devDependencies": {
-    "@defichain/testcontainers": ">=0.18.0",
-    "@defichain/testing": ">=0.18.0"
+    "@defichain/testcontainers": ">=0.22.0",
+    "@defichain/testing": ">=0.22.0"
   }
 }

--- a/packages/salmon-oracles-functions/src/oraclesManager.ts
+++ b/packages/salmon-oracles-functions/src/oraclesManager.ts
@@ -1,15 +1,10 @@
-import {
-  FeeRateProvider,
-  P2WPKHTransactionBuilder,
-  PrevoutProvider
-} from '@defichain/jellyfish-transaction-builder'
+import { FeeRateProvider, P2WPKHTransactionBuilder, PrevoutProvider } from '@defichain/jellyfish-transaction-builder'
 import { SmartBuffer } from 'smart-buffer'
 import { EllipticPair, WIF } from '@defichain/jellyfish-crypto'
-import { CTransactionSegWit, OP_CODES, Script, TransactionSegWit } from '@defichain/jellyfish-transaction'
-import { TokenPrice } from '@defichain/jellyfish-transaction/dist/script/defi/dftx_price'
+import { CTransactionSegWit, OP_CODES, Script, TokenPrice, TransactionSegWit } from '@defichain/jellyfish-transaction'
 import { HASH160 } from '@defichain/jellyfish-crypto/dist/hash'
 import { WhaleApiClient } from '@defichain/whale-api-client'
-import { WhaleWalletAccount, WhalePrevoutProvider, WhaleFeeRateProvider } from '@defichain/whale-api-wallet'
+import { WhaleFeeRateProvider, WhalePrevoutProvider, WhaleWalletAccount } from '@defichain/whale-api-wallet'
 import { getNetwork, NetworkName } from '@defichain/jellyfish-network'
 import { SalmonWalletHDNode } from './salmonWalletHDNode'
 import BigNumber from 'bignumber.js'
@@ -97,8 +92,7 @@ export class OraclesManager {
 
     const ellipticPair = WIF.asEllipticPair(privKey)
     const hdNode = new SalmonWalletHDNode(ellipticPair)
-    const walletAccount = new WhaleWalletAccount(whaleClient, hdNode,
-      getNetwork(network as NetworkName))
+    const walletAccount = new WhaleWalletAccount(whaleClient, hdNode, getNetwork(network as NetworkName))
 
     const prevout = new WhalePrevoutProvider(walletAccount, 10)
     const feeRate = new WhaleFeeRateProvider(whaleClient)

--- a/packages/salmon-price-functions/package.json
+++ b/packages/salmon-price-functions/package.json
@@ -40,8 +40,8 @@
   "dependencies": {
   },
   "devDependencies": {
-    "@defichain/testcontainers": ">=0.18.0",
-    "@defichain/testing": ">=0.18.0",
+    "@defichain/testcontainers": ">=0.22.0",
+    "@defichain/testing": ">=0.22.0",
     "@types/lossless-json": "^1.0.0"
   }
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -7,7 +7,6 @@
     "module": "commonjs",
     "moduleResolution": "node",
     "strict": true,
-    "esModuleInterop": true,
-    "noUnusedLocals": true
+    "esModuleInterop": true
   }
 }


### PR DESCRIPTION
#### What kind of PR is this?:
/kind dependencies
#### What this PR does / why we need it:
Bump `@defichain/*` dependencies to the newest release.

> There were more utility at whale and jellyfish that reduces the amount of code you need to implement signing and broadcasting. But some are they breaking change, I won't implement them here.