### PR TITLE
`lambda-prevout-provider` `fallback-prevout-provider`

### DIFF
--- a/packages/salmon-lambda-functions/src/generic/index.ts
+++ b/packages/salmon-lambda-functions/src/generic/index.ts
@@ -1,9 +1,12 @@
 import { PriceManager, PriceProvider, AssetPrice } from '@defichain/salmon-price-functions'
 import { OraclesManager } from '@defichain/salmon-oracles-functions'
+import { Prevout } from '@defichain/jellyfish-transaction-builder/dist'
 import { getEnvironmentConfig, EnvironmentConfig } from './environment'
 import { checkBalanceAndNotify } from './slack'
+import { LambdaPrevoutProvider } from './lambdaPrevoutProvider'
 
-const broadcastPrices = async (oraclesManager: OraclesManager, env: EnvironmentConfig, prices: AssetPrice[]): Promise<string | undefined> => {
+const broadcastPrices = async (oraclesManager: OraclesManager, env: EnvironmentConfig, prices: AssetPrice[]):
+Promise<Prevout | undefined> => {
   return await oraclesManager.updatePrices(env.oracleId,
     prices.map(assetPrice => ({
       token: assetPrice.asset, prices: [{ currency: env.currency, amount: assetPrice.price }]
@@ -21,12 +24,13 @@ export async function handleGenericPriceApiProvider (provider: PriceProvider, ev
   const prices = await fetchPrices(env, provider)
   console.log(JSON.stringify({ prices, event }))
 
-  const oraclesManager = OraclesManager.withWhaleClient(env.oceanUrl, env.network, env.privateKey)
+  const oraclesManager =
+    OraclesManager.withWhaleClient(env.oceanUrl, env.network, env.privateKey, new LambdaPrevoutProvider())
 
   try {
-    const txid = await broadcastPrices(oraclesManager, env, prices)
-    if (txid !== undefined) {
-      console.log(`Sent with txid: ${txid}`)
+    const prevout = await broadcastPrices(oraclesManager, env, prices)
+    if (prevout !== undefined) {
+      process.stdout.write(`${JSON.stringify(prevout)}`)
     }
   } finally {
     // This gets called even if we escalate the exception, as

--- a/packages/salmon-lambda-functions/src/generic/lambdaPrevoutProvider.ts
+++ b/packages/salmon-lambda-functions/src/generic/lambdaPrevoutProvider.ts
@@ -1,0 +1,77 @@
+import { Prevout, PrevoutProvider } from '@defichain/jellyfish-transaction-builder/dist'
+import AWS from 'aws-sdk'
+import BigNumber from 'bignumber.js'
+
+const SEEK_MINUTES = 10
+const VOUT_LOG_START = '\tINFO\t'
+const functionName = process.env.AWS_LAMBDA_FUNCTION_NAME ?? ''
+const logGroupPrefix = '/aws/lambda/'
+
+export class LambdaPrevoutProvider implements PrevoutProvider {
+  async all (): Promise<Prevout[]> {
+    const logGroupName = `${logGroupPrefix}${functionName}`
+    const cloudwatchlogs = new AWS.CloudWatchLogs({ apiVersion: '2014-03-28' })
+    return await new Promise<Prevout[]>((resolve, reject) => {
+      const groupParams = {
+        logGroupName: logGroupName,
+        descending: true,
+        orderBy: 'LastEventTime'
+      }
+
+      cloudwatchlogs.describeLogStreams(groupParams, (_, groupData) => {
+        const logStreams = groupData.logStreams
+        if (logStreams === undefined) {
+          reject(new Error('Log stream undefined'))
+          return
+        }
+
+        const params = {
+          logGroupName: logGroupName,
+          logStreamName: logStreams[0].logStreamName ?? '',
+          startTime: Date.now() - (1000 * 60 * SEEK_MINUTES)
+        }
+        cloudwatchlogs.getLogEvents(params, (_, data) => {
+          const mapped = (data.events ?? []).flatMap(x => {
+            try {
+              const message = x.message
+              if (message === undefined) {
+                return []
+              }
+
+              const startPos: number = message.indexOf(VOUT_LOG_START)
+              if (startPos === -1) {
+                return []
+              }
+
+              const trimmedMessage = message.substring(startPos + VOUT_LOG_START.length)
+              const prevout = JSON.parse(trimmedMessage)
+              if (prevout.vout !== undefined &&
+                  prevout.txid !== undefined &&
+                  prevout.value !== undefined &&
+                  prevout.script !== undefined &&
+                  prevout.tokenId !== undefined) {
+                return [prevout]
+              }
+            } catch {}
+
+            return []
+          })
+
+          if (mapped.length === 0) {
+            reject(new Error('No prevouts available'))
+            return
+          }
+
+          // Return strictly the latest prevout as upstream may
+          // choose in any order
+          resolve(mapped.reverse()[0])
+        })
+      })
+    })
+  }
+
+  async collect (_: BigNumber): Promise<Prevout[]> {
+    // TODO(fuxingloh): min balance filtering
+    return await this.all()
+  }
+}

--- a/packages/salmon-oracles-functions/__tests__/provider.mock.ts
+++ b/packages/salmon-oracles-functions/__tests__/provider.mock.ts
@@ -136,3 +136,16 @@ export class MockWalletAccount extends WalletAccount {
     return true
   }
 }
+
+export class MockPrevoutListProvider implements PrevoutProvider {
+  public prevoutList: Prevout[] = []
+
+  async all (): Promise<Prevout[]> {
+    return this.prevoutList
+  }
+
+  async collect (_: BigNumber): Promise<Prevout[]> {
+    // TODO(fuxingloh): min balance filtering
+    return await this.all()
+  }
+}

--- a/packages/salmon-oracles-functions/src/index.ts
+++ b/packages/salmon-oracles-functions/src/index.ts
@@ -1,1 +1,2 @@
 export * from './oraclesManager'
+export * from './salmonWalletAccount'

--- a/packages/salmon-oracles-functions/src/salmonWalletAccount.ts
+++ b/packages/salmon-oracles-functions/src/salmonWalletAccount.ts
@@ -1,0 +1,58 @@
+import { WalletEllipticPair } from '@defichain/jellyfish-wallet'
+import { WhaleApiClient } from '@defichain/whale-api-client'
+import { WhaleWalletAccount } from '@defichain/whale-api-wallet'
+import { Network } from '@defichain/jellyfish-network'
+import { P2WPKHTransactionBuilder, Prevout, PrevoutProvider } from '@defichain/jellyfish-transaction-builder/dist'
+import BigNumber from 'bignumber.js'
+
+/**
+ * FallbackPrevoutProvider provides an abstraction that takes
+ * a fallback prevout provider, and a preferred prevout provider.
+ * If the preferred provider is empty or throws an error, the fallback
+ * provider is used.
+ */
+export class FallbackPrevoutProvider implements PrevoutProvider {
+  constructor (
+    protected readonly fallbackPrevoutProvider: PrevoutProvider,
+    protected readonly preferredPrevoutProvider?: PrevoutProvider
+  ) {
+  }
+
+  async all (): Promise<Prevout[]> {
+    if (this.preferredPrevoutProvider !== undefined) {
+      try {
+        const prevouts: Prevout[] = await this.preferredPrevoutProvider.all()
+        if (prevouts.length > 0) {
+          return prevouts
+        }
+      } catch {}
+    }
+
+    return await this.fallbackPrevoutProvider.all()
+  }
+
+  async collect (_: BigNumber): Promise<Prevout[]> {
+    // TODO(fuxingloh): min balance filtering
+    return await this.all()
+  }
+}
+
+export class SalmonWalletAccount extends WhaleWalletAccount {
+  protected readonly salmonPrevoutProvider: PrevoutProvider
+
+  constructor (
+    public readonly client: WhaleApiClient,
+    walletEllipticPair: WalletEllipticPair,
+    network: Network,
+    preferredPrevoutProvider?: PrevoutProvider
+  ) {
+    super(client, walletEllipticPair, network, 10)
+    this.salmonPrevoutProvider = new FallbackPrevoutProvider(this.prevoutProvider, preferredPrevoutProvider)
+  }
+
+  withTransactionBuilder (): P2WPKHTransactionBuilder {
+    return new P2WPKHTransactionBuilder(this.feeRateProvider, this.salmonPrevoutProvider, {
+      get: (_) => this
+    })
+  }
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind feature

#### What this PR does / why we need it:

As whale cannot technically "index" unconfirmed prevouts, it must rely on `listunspent => include_unsafe`, which would be detrimental to whale infrastructure. The only other solution being that the client must keep track of prevouts. As Lambda does not persist state, nor do we want to maintain a database, an alternative implementation is required.

This failsafe provider uses the cloudwatch logs to fetch the prevout used in the last transaction, in the case where this causes any kind of issue, the whale client provider is used as a fallback.

#### Which issue(s) does this PR fixes?:
<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Additional comments?:
