### PR TITLE
Remove timestamp filter

### DIFF
--- a/packages/salmon-lambda-functions/src/generic/index.ts
+++ b/packages/salmon-lambda-functions/src/generic/index.ts
@@ -3,9 +3,6 @@ import { WhaleOraclesManager } from '@defichain/salmon-oracles-functions'
 import { getEnvironmentConfig, EnvironmentConfig } from './environment'
 import { checkBalanceAndNotify } from './slack'
 
-// Maximum price age in minutes
-const MAX_PRICE_AGE = 30
-
 export async function broadcastPrices (oraclesManager: WhaleOraclesManager, env: EnvironmentConfig, prices: AssetPrice[]): Promise<string | undefined> {
   const tokenPrices = prices.map(assetPrice => ({
     token: assetPrice.asset, prices: [{ currency: env.currency, amount: assetPrice.price }]
@@ -17,8 +14,7 @@ export async function broadcastPrices (oraclesManager: WhaleOraclesManager, env:
 
 export async function fetchPrices (env: EnvironmentConfig, provider: PriceProvider): Promise<AssetPrice[]> {
   const priceManager = new PriceManager({ symbols: env.symbols }, provider)
-  return PriceManager.filterTimestamps(await priceManager.fetchAssetPrices(),
-    MAX_PRICE_AGE * 60 * 1000)
+  return await priceManager.fetchAssetPrices()
 }
 
 export async function handleGenericPriceApiProvider (provider: PriceProvider, event?: any): Promise<any> {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind refactor

#### What this PR does / why we need it:

With #139 merged checking the timestamp age is no longer necessary, the double-checking is introducing some code debt and potentially adding more issues than it's solving. Now salmon will simply submit the latest price if it has changed from the previous submitted price.

#### Which issue(s) does this PR fixes?:
<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Additional comments?:
