### PR TITLE
Silence txn conflict error

### DIFF
--- a/packages/salmon-lambda-functions/src/generic/index.ts
+++ b/packages/salmon-lambda-functions/src/generic/index.ts
@@ -34,6 +34,12 @@ export async function handleGenericPriceApiProvider (provider: PriceProvider, ev
     if (txid !== undefined) {
       console.log(`Sent with txid: ${txid}`)
     }
+  } catch (e) {
+    if (e.message.indexOf('txn-mempool-conflict') !== -1) {
+      console.log('txn-mempool-conflict (code 18)')
+    } else {
+      throw e
+    }
   } finally {
     // This gets called even if we escalate the exception, as
     // it may be caused by low balance


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind chore

#### What this PR does / why we need it:

Due to the existing prevout provider, txn-conflict errors can be common, this can raise many false alarms. Until an alternative prevout provider is implemented, this silences specifically `txn-mempool-conflict` errors.

#### Which issue(s) does this PR fixes?:
<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Additional comments?:
